### PR TITLE
Implement Placeholders in Item Lore and Titles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
     maven {
         name = "sonatype"
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+        url = "https://oss.sonatype.org/content/repositories/snapshots/"
     }
 
     maven {

--- a/src/main/java/to/itsme/itsmyconfig/ItsMyConfig.java
+++ b/src/main/java/to/itsme/itsmyconfig/ItsMyConfig.java
@@ -52,6 +52,7 @@ public final class ItsMyConfig extends JavaPlugin {
         final ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
         protocolManager.addPacketListener(new PacketChatListener(this, PacketType.Play.Server.DISGUISED_CHAT, PacketType.Play.Server.SYSTEM_CHAT));
         protocolManager.addPacketListener(new PacketChatListener(this, PacketType.Play.Server.CHAT));
+        protocolManager.addPacketListener(new PacketItemListener(this, PacketType.Play.Server.SET_SLOT, PacketType.Play.Server.WINDOW_ITEMS));
     }
 
     public void loadConfig() {

--- a/src/main/java/to/itsme/itsmyconfig/PacketItemListener.java
+++ b/src/main/java/to/itsme/itsmyconfig/PacketItemListener.java
@@ -1,0 +1,134 @@
+package to.itsme.itsmyconfig;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.reflect.StructureModifier;
+import com.comphenix.protocol.wrappers.nbt.NbtCompound;
+import com.comphenix.protocol.wrappers.nbt.NbtFactory;
+import com.comphenix.protocol.wrappers.nbt.NbtList;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import to.itsme.itsmyconfig.util.Utilities;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public final class PacketItemListener extends PacketAdapter {
+
+    private final ItsMyConfig plugin;
+    private final Pattern colorSymbolPattern;
+    private final Pattern symbolPrefixPattern;
+    private final Pattern tagPattern = Pattern.compile("<(?:\\\\.|[^<>])*>");
+    private final GsonComponentSerializer gsonComponentSerializer = GsonComponentSerializer.gson();
+
+    public PacketItemListener(
+            final ItsMyConfig plugin,
+            final PacketType... types
+    ) {
+        super(plugin, ListenerPriority.NORMAL, types);
+        this.plugin = plugin;
+        this.colorSymbolPattern = Pattern.compile(Pattern.quote("§"));
+        this.symbolPrefixPattern = Pattern.compile(Pattern.quote(plugin.getSymbolPrefix()));
+    }
+
+    @Override
+    public void onPacketSending(final PacketEvent event) {
+        final PacketContainer packetContainer = event.getPacket();
+        final Player player = event.getPlayer();
+
+        if (event.getPacketType() == PacketType.Play.Server.SET_SLOT) {
+            final StructureModifier<ItemStack> itemModifier = packetContainer.getItemModifier();
+            final ItemStack itemStack = itemModifier.readSafely(0);
+            processItem(itemStack, player);
+            itemModifier.write(0, itemStack);
+        } else if (event.getPacketType() == PacketType.Play.Server.WINDOW_ITEMS) {
+            final StructureModifier<List<ItemStack>> itemArrayModifier = packetContainer.getItemListModifier();
+            final List<ItemStack> itemStacks = itemArrayModifier.readSafely(0);
+            itemStacks.forEach(itemStack -> processItem(itemStack, player));
+            itemArrayModifier.write(0, itemStacks);
+        }
+    }
+
+    private void processItem(ItemStack itemStack, Player player) {
+        if (itemStack == null || itemStack.getType() == Material.AIR) {
+            return;
+        }
+
+        final NbtCompound itemNbt = (NbtCompound) NbtFactory.fromItemTag(itemStack);
+
+        if (itemNbt == null || !itemNbt.containsKey("display")) {
+            return;
+        }
+
+        final NbtCompound displayNbt = itemNbt.getCompound("display");
+
+        if (displayNbt.containsKey("Name")) {
+            BaseComponent[] components = ComponentSerializer.parse(displayNbt.getString("Name"));
+            TextComponent textComponent = new TextComponent(components);
+            String plainText = textComponent.toLegacyText();
+
+            if (startsWithSymbol(plainText)) {
+                Component translatedComponent = Utilities.translate(processMessage(plainText), player)
+                        .decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE);
+                Utilities.applyChatColors(translatedComponent);
+                displayNbt.put("Name", gsonComponentSerializer.serialize(translatedComponent));
+            }
+        }
+
+        if (displayNbt.containsKey("Lore")) {
+            final NbtList<String> loreNbt = displayNbt.getList("Lore");
+
+            if (loreNbt == null || loreNbt.size() == 0) {
+                return;
+            }
+
+            final List<String> processedLore = new ArrayList<>();
+            for (final String loreLine : loreNbt) {
+                BaseComponent[] components = ComponentSerializer.parse(loreLine);
+                TextComponent textComponent = new TextComponent(components);
+                String plainText = textComponent.toLegacyText();
+
+                if (startsWithSymbol(plainText)) {
+                    Component translatedComponent = Utilities.translate(processMessage(plainText), player)
+                            .decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE);
+                    Utilities.applyChatColors(translatedComponent);
+                    processedLore.add(gsonComponentSerializer.serialize(translatedComponent));
+                } else {
+                    processedLore.add(loreLine);
+                }
+            }
+
+            final NbtList<String> newLoreNbt = NbtFactory.ofList("Lore");
+            processedLore.stream()
+                    .filter(loreText -> !loreText.isEmpty())
+                    .map(loreText -> ChatColor.translateAlternateColorCodes('&', loreText))
+                    .forEach(newLoreNbt::add);
+
+            displayNbt.put("Lore", newLoreNbt);
+        }
+
+        itemNbt.put("display", displayNbt);
+        NbtFactory.setItemTag(itemStack, itemNbt);
+    }
+
+    private boolean startsWithSymbol(final String message) {
+        return message != null && !message.isEmpty() &&
+                tagPattern.matcher(Utilities.colorless(message)).replaceAll("").trim().startsWith(plugin.getSymbolPrefix());
+    }
+
+    private String processMessage(final String message) {
+        return colorSymbolPattern.matcher(symbolPrefixPattern.matcher(message).replaceFirst("")).replaceAll("&");
+    }
+}


### PR DESCRIPTION
#### Description
This pull request introduces the `PacketItemListener` class, which is designed to handle the incorporation of placeholders in the lore and titles of items within the game. The listener class specifically responds to the `SET_SLOT` and `WINDOW_ITEMS` packet types, allowing for dynamic updating of item descriptions as they are interacted with in the UI.

#### Key features implemented:
**PacketItemListener Class**: Listens to `SET_SLOT` and `WINDOW_ITEMS` packets and modifies item lore and titles to include placeholders dynamically using NBT tags and components serializers.

#### Changes
- Modified `ItsMyConfig.java` to instantiate the new packet listener.
- Added `PacketItemListener.java` which contains the logic for intercepting and modifying item packets.
- Updated `build.gradle` to change the repository configuration to the official Sonatype repository.

#### Testing
- Manual testing was conducted to ensure that placeholders are correctly inserted and displayed in item lore and titles.