### PR TITLE
.toLowerCase() to fix bossbar tag

### DIFF
--- a/core/src/main/java/to/itsme/itsmyconfig/tag/impl/BossbarTag.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/tag/impl/BossbarTag.java
@@ -55,8 +55,8 @@ public class BossbarTag extends ArgumentsTag implements Cancellable {
             final Player player,
             final String[] arguments
     ) {
-        final BossBar.Color color = BossBar.Color.NAMES.value(arguments[2]);
-        final BossBar.Overlay overlay = BossBar.Overlay.NAMES.value(arguments[3]);
+        final BossBar.Color color = BossBar.Color.NAMES.value(arguments[2].toLowerCase());
+        final BossBar.Overlay overlay = BossBar.Overlay.NAMES.value(arguments[3].toLowerCase());
 
         long delay;
         if (arguments.length > 4) {


### PR DESCRIPTION
This update fixes the BOSBAR Color and Overlay
<img width="436" height="68" alt="image" src="https://github.com/user-attachments/assets/40c626d6-3a55-4d28-a5dc-02f007658b55" />
