### PR TITLE
fix: prevent NPE when checking player online status

### DIFF
--- a/core/src/main/java/to/itsme/itsmyconfig/util/Utilities.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/util/Utilities.java
@@ -151,7 +151,7 @@ public final class Utilities {
             final OfflinePlayer player,
             final TagResolver... placeholders
     ) {
-        if (player.isOnline()) {
+        if (player != null && player.isOnline()) {
             return translate(text, player.getPlayer(), placeholders);
         }
 


### PR DESCRIPTION
Fix an issue where `OfflinePlayer#isOnline()` was called without verifying that the player instance was non-null, causing a `NullPointerException`.