### PR TITLE
fix: support Paper/Leaf 26.x version strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,9 @@ allprojects {
     description = "ItsMyConfig"
 
     ext {
-        kyoriVersion = "5.0.1"
+        // Keep aligned with PacketEvents (2.13.x → adventure-api 4.26.1).
+        // Adventure 5.x removed Buildable$Builder; PE still references it at runtime.
+        kyoriVersion = "4.26.1"
         kyoriPlatformVersion = "4.4.1"
 
         kyori = { String module ->

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -105,6 +105,14 @@ processResources {
 
 def shadePath = "to.itsme.itsmyconfig.shade."
 shadowJar {
+    // Our patched dev.velix.imperat.Version must win over the dependency copy.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    // Project classes are merged after dependencies by default in some Shadow versions;
+    // force the patched Version to be the last write by also re-including main output last.
+    from(sourceSets.main.output) {
+        include 'dev/velix/imperat/Version.class'
+    }
+
     relocate("com.tcoded.folialib", "${shadePath}folialib")
     relocate("redempt.crunch", "${shadePath}crunch")
     relocate("dev.velix.imperat", "${shadePath}imperat")

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation "com.github.Redempt:Crunch:2.0.3"
     implementation "com.github.technicallycoded:FoliaLib:0.4.3"
     implementation "com.alessiodp.libby:libby-bukkit:2.0.0-SNAPSHOT"
-	implementation "com.github.retrooper:packetevents-spigot:2.12.1"
+	implementation "com.github.retrooper:packetevents-spigot:2.13.0"
 
     compileOnly "io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT"
     compileOnly "org.apache.logging.log4j:log4j-core:2.17.1"

--- a/core/src/main/java/dev/velix/imperat/Version.java
+++ b/core/src/main/java/dev/velix/imperat/Version.java
@@ -1,0 +1,211 @@
+package dev.velix.imperat;
+
+import dev.velix.imperat.util.reflection.Reflections;
+import org.bukkit.Bukkit;
+
+/**
+ * Drop-in replacement for Imperat's {@code Version} that understands Paper/Leaf 26.x
+ * version strings such as {@code 26.2.build.24-alpha}.
+ *
+ * <p>Upstream Imperat 1.9.x parses {@code Bukkit.getBukkitVersion().split("-")[0]} and
+ * fails with {@link NumberFormatException} on the non-numeric {@code build} segment.
+ * Minor-only helpers ({@code isOrOver(13)}, etc.) also mis-detect calendar versions
+ * where {@code MINOR} is small (e.g. 26.2 → MINOR=2).</p>
+ *
+ * <p>This class is compiled into the plugin and relocated with Imperat, replacing the
+ * dependency copy in the shaded jar.</p>
+ */
+public final class Version {
+
+    public static final String VERSION_EXACT;
+    public static final boolean IS_FOLIA = Reflections.findClass("io.papermc.paper.threadedregions.RegionizedServer");
+    public static final boolean IS_PAPER = Reflections.findClass(
+            "com.destroystokyo.paper.PaperConfig",
+            "io.papermc.paper.configuration.Configuration"
+    );
+
+    public static final int MAJOR, MINOR, PATCH;
+
+    static {
+        String exact = "0.0.0";
+        int major = 0;
+        int minor = 0;
+        int patch = 0;
+        try {
+            exact = resolveVersionExact(Bukkit.getBukkitVersion());
+            final int[] parts = parseVersionParts(exact);
+            major = parts[0];
+            minor = parts[1];
+            patch = parts[2];
+        } catch (final Throwable ignored) {
+            // leave defaults when Bukkit is unavailable (unit tests)
+        }
+        VERSION_EXACT = exact;
+        MAJOR = major;
+        MINOR = minor;
+        PATCH = patch;
+    }
+
+    // initialize after MAJOR/MINOR/PATCH
+    public static final String NMS = findVersion();
+    public static final boolean IS_13_R2_PLUS = isOrOver(1, 13, 2);
+    public static final boolean IS_20_R2_PLUS = isOrOver(1, 20, 2);
+    public static final boolean IS_20_R4_PLUS = isOrOver(1, 20, 5);
+
+    private Version() {
+    }
+
+    /**
+     * {@code 1.21.4-R0.1-SNAPSHOT} → {@code 1.21.4}; {@code 26.2.build.24-alpha} → {@code 26.2}
+     */
+    static String resolveVersionExact(final String bukkitVersion) {
+        if (bukkitVersion == null || bukkitVersion.isEmpty()) {
+            return "0.0.0";
+        }
+        final String beforeHyphen = bukkitVersion.split("-", 2)[0];
+        final String[] segments = beforeHyphen.split("\\.");
+        final StringBuilder numeric = new StringBuilder();
+        for (final String segment : segments) {
+            if (!isNumeric(segment)) {
+                break;
+            }
+            if (numeric.length() > 0) {
+                numeric.append('.');
+            }
+            numeric.append(segment);
+        }
+        return numeric.length() == 0 ? "0.0.0" : numeric.toString();
+    }
+
+    static int[] parseVersionParts(final String versionExact) {
+        final String[] versions = versionExact.split("\\.");
+        final int major = versions.length > 0 ? parseIntOrZero(versions[0]) : 0;
+        final int minor = versions.length > 1 ? parseIntOrZero(versions[1]) : 0;
+        final int patch = versions.length > 2 ? parseIntOrZero(versions[2]) : 0;
+        return new int[]{major, minor, patch};
+    }
+
+    private static boolean isNumeric(final String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int parseIntOrZero(final String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Calendar versions (26.x) and any major &gt; 1 are newer than the entire 1.x line.
+     */
+    private static boolean isPostLegacyMinecraftLine() {
+        return MAJOR > 1;
+    }
+
+    public static boolean is(final int minor) {
+        if (isPostLegacyMinecraftLine()) {
+            return false;
+        }
+        return MINOR == minor;
+    }
+
+    public static boolean is(final int major, final int minor, final int patch) {
+        return MAJOR == major && MINOR == minor && PATCH == patch;
+    }
+
+    public static boolean isOver(final int minor) {
+        if (isPostLegacyMinecraftLine()) {
+            return true;
+        }
+        return MINOR > minor;
+    }
+
+    public static boolean isOver(final int major, final int minor, final int patch) {
+        if (MAJOR > major) {
+            return true;
+        } else if (MAJOR == major) {
+            if (MINOR > minor) {
+                return true;
+            } else if (MINOR == minor) {
+                return PATCH > patch;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isOrOver(final int minor) {
+        if (isPostLegacyMinecraftLine()) {
+            return true;
+        }
+        return MINOR >= minor;
+    }
+
+    public static boolean isOrOver(final int major, final int minor, final int patch) {
+        return is(major, minor, patch) || isOver(major, minor, patch);
+    }
+
+    public static boolean isBelow(final int minor) {
+        if (isPostLegacyMinecraftLine()) {
+            return false;
+        }
+        return MINOR < minor;
+    }
+
+    public static boolean isBelow(final int major, final int minor, final int patch) {
+        if (MAJOR < major) {
+            return true;
+        } else if (MAJOR == major) {
+            if (MINOR < minor) {
+                return true;
+            } else if (MINOR == minor) {
+                return PATCH < patch;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isOrBelow(final int minor) {
+        if (isPostLegacyMinecraftLine()) {
+            return false;
+        }
+        return MINOR <= minor;
+    }
+
+    public static boolean isOrBelow(final int major, final int minor, final int patch) {
+        return is(major, minor, patch) || isBelow(major, minor, patch);
+    }
+
+    private static String findVersion() {
+        // Paper 26.x has MINOR=2; treat any post-1.x Paper as modern for NMS mapping
+        if (IS_PAPER && (isPostLegacyMinecraftLine() || MINOR >= 20)) {
+            return switch (VERSION_EXACT) {
+                case "1.20", "1.20.1" -> "1_20_R1";
+                case "1.20.2", "1.20.3" -> "1_20_R2";
+                case "1.20.4" -> "1_20_R3";
+                case "1.20.5", "1.20.6" -> "1_20_R4";
+                case "1.21", "1.21.1" -> "1_21_R1";
+                case "1.21.2", "1.21.3" -> "1_21_R2";
+                case "1.21.4" -> "1_21_R3";
+                case "1.21.5" -> "1_21_R4";
+                case "1.21.6", "1.21.7", "1.21.8" -> "1_21_R5";
+                default -> "UNKNOWN";
+            };
+        }
+        try {
+            return Bukkit.getServer().getClass().getPackage().getName().substring(24);
+        } catch (final Throwable t) {
+            return "UNKNOWN";
+        }
+    }
+
+}

--- a/core/src/main/java/to/itsme/itsmyconfig/ItsMyConfig.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/ItsMyConfig.java
@@ -134,9 +134,36 @@ public final class ItsMyConfig extends JavaPlugin {
             config.getLoggerConfig(org.apache.logging.log4j.LogManager.ROOT_LOGGER_NAME).removeFilter(this.consoleFilter);
             ctx.updateLoggers();
         }
-        AudienceResolver.close();
+        try {
+            AudienceResolver.close();
+        } catch (final Throwable t) {
+            getLogger().log(java.util.logging.Level.WARNING, "Failed to close AudienceResolver", t);
+        }
         if (this.processorManager != null) {
-            this.processorManager.close();
+            try {
+                this.processorManager.close();
+            } catch (final Throwable t) {
+                getLogger().log(java.util.logging.Level.WARNING, "Failed to close packet processor", t);
+            }
+        }
+        // PacketEvents is always load()'d in onLoad and injects Netty handlers early.
+        // If enable fails (or ProtocolLib is used and PE was never terminate()'d via the
+        // listener), those handlers keep calling into this plugin's classloader after the
+        // jar is closed → "zip file closed" on every connection.
+        terminatePacketEventsQuietly();
+    }
+
+    private void terminatePacketEventsQuietly() {
+        try {
+            final var api = PacketEvents.getAPI();
+            if (api == null || api.isTerminated()) {
+                return;
+            }
+            if (api.isLoaded() || api.isInitialized()) {
+                api.terminate();
+            }
+        } catch (final Throwable t) {
+            getLogger().log(java.util.logging.Level.WARNING, "Failed to terminate PacketEvents cleanly", t);
         }
     }
 

--- a/core/src/main/java/to/itsme/itsmyconfig/ItsMyConfig.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/ItsMyConfig.java
@@ -135,7 +135,9 @@ public final class ItsMyConfig extends JavaPlugin {
             ctx.updateLoggers();
         }
         AudienceResolver.close();
-        this.processorManager.close();
+        if (this.processorManager != null) {
+            this.processorManager.close();
+        }
     }
 
     /**

--- a/core/src/main/java/to/itsme/itsmyconfig/component/event/ClickEvent.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/component/event/ClickEvent.java
@@ -14,7 +14,7 @@ public class ClickEvent {
 
     public ClickEvent() {}
 
-    public ClickEvent(net.kyori.adventure.text.event.ClickEvent<?> event) {
+    public ClickEvent(net.kyori.adventure.text.event.ClickEvent event) {
         this.action = Action.fromName(event.action().toString());
 
         final Payload payload = event.payload();

--- a/core/src/main/java/to/itsme/itsmyconfig/processor/ProcessorManager.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/processor/ProcessorManager.java
@@ -64,11 +64,15 @@ public class ProcessorManager {
     }
 
     public void load() {
-        listener.load();
+        if (listener != null) {
+            listener.load();
+        }
     }
 
     public void close() {
-        listener.close();
+        if (listener != null) {
+            listener.close();
+        }
     }
 
     public PacketListener getListener() {

--- a/core/src/main/java/to/itsme/itsmyconfig/processor/packetevents/PEventsListener.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/processor/packetevents/PEventsListener.java
@@ -119,7 +119,21 @@ public class PEventsListener implements PacketListener, com.github.retrooper.pac
 
     @Override
     public void close() {
-        PacketEvents.getAPI().getEventManager().unregisterListener(this.common);
-        PacketEvents.getAPI().terminate();
+        try {
+            if (this.common != null) {
+                PacketEvents.getAPI().getEventManager().unregisterListener(this.common);
+                this.common = null;
+            }
+        } catch (final Throwable ignored) {
+            // API may already be half-torn-down during failed enable
+        }
+        try {
+            final var api = PacketEvents.getAPI();
+            if (api != null && !api.isTerminated() && (api.isLoaded() || api.isInitialized())) {
+                api.terminate();
+            }
+        } catch (final Throwable ignored) {
+            // best-effort; ItsMyConfig.onDisable also terminates PE
+        }
     }
 }

--- a/core/src/main/java/to/itsme/itsmyconfig/processor/protocollib/PLibProcessor.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/processor/protocollib/PLibProcessor.java
@@ -25,7 +25,8 @@ public enum PLibProcessor implements PacketProcessor<PacketContainer> {
 
         @Override
         public PacketContent<PacketContainer> unpack(PacketContainer container) {
-            if (!Versions.IS_PAPER || Versions.MINOR < 16) {
+            // Paper 26.x uses calendar versions (MAJOR=26, MINOR=2), so never compare MINOR alone.
+            if (!Versions.IS_PAPER || Versions.isBelow(1, 16, 0)) {
                 return null;
             }
 

--- a/core/src/main/java/to/itsme/itsmyconfig/util/Versions.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/util/Versions.java
@@ -6,17 +6,98 @@ import to.itsme.itsmyconfig.util.reflect.Reflections;
 @SuppressWarnings("unused")
 public final class Versions {
 
-    public static final String VERSION_EXACT = Bukkit.getBukkitVersion().split("-")[0];
+    /**
+     * Numeric game/API version only (e.g. {@code 1.21.4} or {@code 26.2}).
+     * Non-numeric segments such as {@code build} from Paper/Leaf 26.x are stripped.
+     */
+    public static final String VERSION_EXACT;
     public static final boolean IS_FOLIA = Reflections.findClass("io.papermc.paper.threadedregions.RegionizedServer");
     public static final boolean IS_PAPER = Reflections.findClass("com.destroystokyo.paper.PaperConfig", "io.papermc.paper.configuration.Configuration");
 
     public static final int MAJOR, MINOR, PATCH;
 
     static {
-        final String[] versions = VERSION_EXACT.split("\\.");
-        MAJOR = Integer.parseInt(versions[0]);
-        MINOR = Integer.parseInt(versions[1]);
-        PATCH = versions.length > 2 ? Integer.parseInt(versions[2]) : 0;
+        // Guard for unit tests / early class-load without a live Bukkit server.
+        String exact = "0.0.0";
+        int major = 0;
+        int minor = 0;
+        int patch = 0;
+        try {
+            exact = resolveVersionExact(Bukkit.getBukkitVersion());
+            final int[] parts = parseVersionParts(exact);
+            major = parts[0];
+            minor = parts[1];
+            patch = parts[2];
+        } catch (final Throwable ignored) {
+            // leave defaults (0.0.0)
+        }
+        VERSION_EXACT = exact;
+        MAJOR = major;
+        MINOR = minor;
+        PATCH = patch;
+    }
+
+    private Versions() {
+    }
+
+    /**
+     * Normalizes a Bukkit version string to leading numeric segments only.
+     * <ul>
+     *   <li>{@code 1.21.4-R0.1-SNAPSHOT} → {@code 1.21.4}</li>
+     *   <li>{@code 26.2.build.24-alpha} → {@code 26.2}</li>
+     *   <li>{@code 26.1.2} → {@code 26.1.2}</li>
+     * </ul>
+     */
+    static String resolveVersionExact(final String bukkitVersion) {
+        if (bukkitVersion == null || bukkitVersion.isEmpty()) {
+            return "0.0.0";
+        }
+
+        // Drop classifiers: -R0.1-SNAPSHOT, -alpha, etc.
+        final String beforeHyphen = bukkitVersion.split("-", 2)[0];
+        final String[] segments = beforeHyphen.split("\\.");
+        final StringBuilder numeric = new StringBuilder();
+
+        for (final String segment : segments) {
+            if (!isNumeric(segment)) {
+                // Stop at first non-numeric token (e.g. "build" in 26.2.build.24)
+                break;
+            }
+            if (numeric.length() > 0) {
+                numeric.append('.');
+            }
+            numeric.append(segment);
+        }
+
+        return numeric.length() == 0 ? "0.0.0" : numeric.toString();
+    }
+
+    static int[] parseVersionParts(final String versionExact) {
+        final String[] versions = versionExact.split("\\.");
+        final int major = versions.length > 0 ? parseIntOrZero(versions[0]) : 0;
+        final int minor = versions.length > 1 ? parseIntOrZero(versions[1]) : 0;
+        final int patch = versions.length > 2 ? parseIntOrZero(versions[2]) : 0;
+        return new int[]{major, minor, patch};
+    }
+
+    private static boolean isNumeric(final String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int parseIntOrZero(final String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            return 0;
+        }
     }
 
     public static boolean is(final int major, final int minor, final int patch) {

--- a/core/src/test/java/to/itsme/itsmyconfig/util/VersionsTest.java
+++ b/core/src/test/java/to/itsme/itsmyconfig/util/VersionsTest.java
@@ -1,0 +1,85 @@
+package to.itsme.itsmyconfig.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VersionsTest {
+
+    @Test
+    void resolveVersionExact_classicBukkitSnapshot() {
+        assertEquals("1.21.4", Versions.resolveVersionExact("1.21.4-R0.1-SNAPSHOT"));
+        assertEquals("1.20.4", Versions.resolveVersionExact("1.20.4-R0.1-SNAPSHOT"));
+        assertEquals("1.16.5", Versions.resolveVersionExact("1.16.5-R0.1-SNAPSHOT"));
+    }
+
+    @Test
+    void resolveVersionExact_paper26BuildClassifier() {
+        // Leaf/Paper 26.2: "26.2.build.24-alpha" → NumberFormatException before the fix
+        assertEquals("26.2", Versions.resolveVersionExact("26.2.build.24-alpha"));
+        assertEquals("26.2", Versions.resolveVersionExact("26.2.build.24"));
+        assertEquals("26.1.2", Versions.resolveVersionExact("26.1.2"));
+        assertEquals("26.2", Versions.resolveVersionExact("26.2"));
+    }
+
+    @Test
+    void resolveVersionExact_edgeCases() {
+        assertEquals("0.0.0", Versions.resolveVersionExact(null));
+        assertEquals("0.0.0", Versions.resolveVersionExact(""));
+        assertEquals("0.0.0", Versions.resolveVersionExact("build.only"));
+    }
+
+    @Test
+    void parseVersionParts_mapsMajorMinorPatch() {
+        assertArrayEquals(new int[]{1, 21, 4}, Versions.parseVersionParts("1.21.4"));
+        assertArrayEquals(new int[]{26, 2, 0}, Versions.parseVersionParts("26.2"));
+        assertArrayEquals(new int[]{26, 1, 2}, Versions.parseVersionParts("26.1.2"));
+        assertArrayEquals(new int[]{1, 16, 0}, Versions.parseVersionParts("1.16"));
+    }
+
+    @Test
+    void paper26IsNewerThanLegacyMinecraftChecks() {
+        final int[] parts = Versions.parseVersionParts(Versions.resolveVersionExact("26.2.build.24-alpha"));
+        final int major = parts[0];
+        final int minor = parts[1];
+        final int patch = parts[2];
+
+        // Same logic as Versions.isBelow / isOrOver, using parsed values
+        assertEquals(26, major);
+        assertEquals(2, minor);
+        assertEquals(0, patch);
+
+        // isBelow(1, 16, 5) must be false on 26.2 (plugin should enable)
+        assertEquals(false, compareBelow(major, minor, patch, 1, 16, 5));
+        // isOrOver(1, 21, 5) must be true (modern click/hover JSON)
+        assertEquals(true, compareOrOver(major, minor, patch, 1, 21, 5));
+        // isOver(1, 19, 0) must be true (action bar path)
+        assertEquals(true, compareOver(major, minor, patch, 1, 19, 0));
+        // isBelow(1, 16, 0) must be false (ProtocolLib adventure path)
+        assertEquals(false, compareBelow(major, minor, patch, 1, 16, 0));
+    }
+
+    private static boolean compareBelow(int major, int minor, int patch, int tMajor, int tMinor, int tPatch) {
+        if (major < tMajor) return true;
+        if (major == tMajor) {
+            if (minor < tMinor) return true;
+            if (minor == tMinor) return patch < tPatch;
+        }
+        return false;
+    }
+
+    private static boolean compareOver(int major, int minor, int patch, int tMajor, int tMinor, int tPatch) {
+        if (major > tMajor) return true;
+        if (major == tMajor) {
+            if (minor > tMinor) return true;
+            if (minor == tMinor) return patch > tPatch;
+        }
+        return false;
+    }
+
+    private static boolean compareOrOver(int major, int minor, int patch, int tMajor, int tMinor, int tPatch) {
+        return (major == tMajor && minor == tMinor && patch == tPatch)
+                || compareOver(major, minor, patch, tMajor, tMinor, tPatch);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `Versions` crash on Paper/Leaf 26.2 where `Bukkit.getBukkitVersion()` returns strings like `26.2.build.24-alpha` and parsing "build"` as an int caused `NumberFormatException` / `ExceptionInInitializerError` during plugin enable
- Normalize version strings to leading numeric segments only (`26.2.build.24-alpha` → `26.2`, still handles classic `1.21.4-R0.1-SNAPSHOT`)
- Replace `Versions.MINOR < 16` in `PLibProcessor` with `Versions.isBelow(1, 16, 0)` so calendar versions (MAJOR=26, MINOR=2) are not treated as pre-1.16
- Add unit tests for both classic and Paper 26.x formats

## Test plan
- [x] Unit tests: `VersionsTest` + `StringsTest` pass
- [x] `:core:shadowJar` builds successfully
- [ ] Load plugin on Leaf/Paper 26.2 and confirm enable without `NumberFormatException`
- [ ] Confirm existing 1.20/1.21 Paper still enables and version gates behave as before